### PR TITLE
"Adicionar interfaces para o repositório e serviço de Monitoramento d…

### DIFF
--- a/api/src/main/java/com/monitoramento/api/repository/MonitoramentoLogRepository.java
+++ b/api/src/main/java/com/monitoramento/api/repository/MonitoramentoLogRepository.java
@@ -1,0 +1,9 @@
+package com.monitoramento.api.repository;
+
+import com.monitoramento.api.model.MonitoramentoLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MonitoramentoLogRepository extends JpaRepository<MonitoramentoLog, Long> {
+}


### PR DESCRIPTION
**Criação da interface** `MonitoramentoLogRepository:`

- Esta interface define os métodos necessários para interação com o banco de dados para a entidade MonitoramentoLog. Ela estende JpaRepository, que automaticamente fornece as operações de CRUD (criação, leitura, atualização e exclusão) para os registros de monitoramento de logs.
- A interface foi projetada para ser facilmente reutilizável, caso seja necessário criar consultas personalizadas no futuro.