### PR TITLE
feat: Implementação do endpoint para salvar logs de monitoramento e configuração do banco de dados

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Annotation profile for api" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />

--- a/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
+++ b/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
@@ -1,0 +1,29 @@
+package com.monitoramento.api.controller;
+
+import com.monitoramento.api.model.MonitoramentoLog;
+import com.monitoramento.api.service.MonitoramentoLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/monitoramento")
+public class MonitoramentoLogController {
+
+    @Autowired
+    private MonitoramentoLogService monitoramentoLogService;
+
+    @PostMapping("/salvar")
+    @ResponseStatus(HttpStatus.CREATED) // 201 Created quando o log for salvo
+    public MonitoramentoLog salvar(@RequestBody MonitoramentoLog monitoramentoLog){
+        // Salva o log diretamente e retorna o objeto salvo
+        return monitoramentoLogService.salvarLog(monitoramentoLog);
+    }
+
+
+
+}

--- a/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
+++ b/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
@@ -4,17 +4,18 @@ package com.monitoramento.api.service;
 import com.monitoramento.api.model.MonitoramentoLog;
 import com.monitoramento.api.repository.MonitoramentoLogRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MonitoramentoLogService {
 
+    @Autowired
+    private MonitoramentoLogRepository monitoramentoLogRepository;
 
-    private final  MonitoramentoLogRepository monitoramentoLogRepository;
 
-
-    public MonitoramentoLog salvar(MonitoramentoLog log){
+    public MonitoramentoLog salvarLog(MonitoramentoLog log){
         return monitoramentoLogRepository.save(log);
     }
 

--- a/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
+++ b/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
@@ -1,0 +1,23 @@
+package com.monitoramento.api.service;
+
+
+import com.monitoramento.api.model.MonitoramentoLog;
+import com.monitoramento.api.repository.MonitoramentoLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MonitoramentoLogService {
+
+
+    private final  MonitoramentoLogRepository monitoramentoLogRepository;
+
+
+    public MonitoramentoLog salvar(MonitoramentoLog log){
+        return monitoramentoLogRepository.save(log);
+    }
+
+
+
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=api
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/monitoramento_db
+spring.datasource.username=postgres
+spring.datasource.password=1313
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
_**Descrição: Neste PR, foram implementadas as seguintes funcionalidades para o monitoramento de logs:**_

_1. Classe MonitoramentoLogController:_

- Criação de um endpoint POST /api/monitoramento/salvar, responsável por receber um objeto MonitoramentoLog no corpo da requisição e salvá-lo no banco de dados.

- O método retorna o log salvo com status HTTP 201 (Created), indicando que o recurso foi criado com sucesso.

_2. Classe MonitoramentoLogService:_

- Implementação do serviço responsável por interagir com o repositório e salvar o log no banco de dados.

- O método salvarLog() recebe o log, chama o repositório e o persiste no banco.

_3. Configuração de banco de dados no application.properties:_

- Configuração do acesso ao banco de dados para permitir a persistência dos logs de monitoramento.
- Definição da URL do banco de dados, credenciais e configurações de JPA para permitir a comunicação adequada com o banco.