### PR TITLE
feat(controller): adicionar endpoint GET para listar todos os logs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -54,6 +54,14 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.3.0</version> <!-- Use a versão mais recente -->
+		</dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
+++ b/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
@@ -2,11 +2,12 @@ package com.monitoramento.api.controller;
 
 import com.monitoramento.api.model.MonitoramentoLog;
 import com.monitoramento.api.service.MonitoramentoLogService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Repository;
+
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,13 +20,24 @@ public class MonitoramentoLogController {
     @Autowired
     private MonitoramentoLogService monitoramentoLogService;
 
+
+    // Configuração da documentação Swagger
+    @Operation(summary = "Criar um novo log de monitoramento")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Log criado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos fornecidos")
+    })
+    // Endpoint para criar um log
     @PostMapping("/salvar")
-    @ResponseStatus(HttpStatus.CREATED) // 201 Created quando o log for salvo
     public MonitoramentoLog salvar(@RequestBody MonitoramentoLog monitoramentoLog) {
-        // Salva o log diretamente e retorna o objeto salvo
         return monitoramentoLogService.salvarLog(monitoramentoLog);
     }
 
+    @Operation(summary = "Lista todos os logs de monitoramento")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de logs retornada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Nenhum log encontrado")
+    })
     @GetMapping("/logs")
     public List<MonitoramentoLog> listaTodos() {
         return monitoramentoLogService.listarTodos();

--- a/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
+++ b/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/monitoramento")
@@ -19,11 +21,15 @@ public class MonitoramentoLogController {
 
     @PostMapping("/salvar")
     @ResponseStatus(HttpStatus.CREATED) // 201 Created quando o log for salvo
-    public MonitoramentoLog salvar(@RequestBody MonitoramentoLog monitoramentoLog){
+    public MonitoramentoLog salvar(@RequestBody MonitoramentoLog monitoramentoLog) {
         // Salva o log diretamente e retorna o objeto salvo
         return monitoramentoLogService.salvarLog(monitoramentoLog);
     }
 
+    @GetMapping("/logs")
+    public List<MonitoramentoLog> listaTodos() {
+        return monitoramentoLogService.listarTodos();
+    }
 
 
 }

--- a/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
+++ b/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
@@ -17,17 +17,15 @@ public class MonitoramentoLogService {
     @Autowired
     private MonitoramentoLogRepository monitoramentoLogRepository;
 
-
-    public MonitoramentoLog salvarLog(MonitoramentoLog log){
+    public MonitoramentoLog salvarLog(MonitoramentoLog log) {
         return monitoramentoLogRepository.save(log);
     }
 
-
-    public List<MonitoramentoLog> listarTodos(){
+    public List<MonitoramentoLog> listarTodos() {
         return monitoramentoLogRepository.findAll();
     }
 
-    public Optional<MonitoramentoLog> buscarPorId(Long id){
+    public Optional<MonitoramentoLog> buscarPorId(Long id) {
         return monitoramentoLogRepository.findById(id);
     }
 

--- a/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
+++ b/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class MonitoramentoLogService {
@@ -20,5 +23,12 @@ public class MonitoramentoLogService {
     }
 
 
+    public List<MonitoramentoLog> listarTodos(){
+        return monitoramentoLogRepository.findAll();
+    }
+
+    public Optional<MonitoramentoLog> buscarPorId(Long id){
+        return monitoramentoLogRepository.findById(id);
+    }
 
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -5,3 +5,18 @@ spring.datasource.username=postgres
 spring.datasource.password=1313
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+# Caminho personalizado para o Swagger UI
+springdoc.swagger-ui.path=/api/monitoramento/swagger-ui.html
+
+# Ordenar tags e operações alfabeticamente
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=alpha
+
+# Caminho para o endpoint da documentação OpenAPI
+springdoc.api-docs.path=/v3/api-docs
+
+# Informações sobre a API
+springdoc.info.title=Monitoramento API
+springdoc.info.description=API para monitoramento de logs
+springdoc.info.version=1.0.0


### PR DESCRIPTION
## Descrição
**_Este PR adiciona um endpoint GET na classe `MonitoramentoLogController` para listar todos os logs registrados no sistema. O método `listaTodos` foi implementado para retornar uma lista de todos os logs armazenados no banco de dados._**

### O que foi feito:
- Adicionado o método `listaTodos()` na classe `MonitoramentoLogController`.
- O método chama a camada de serviço `MonitoramentoLogService` para recuperar todos os registros de logs.
- A resposta da requisição retorna a lista de logs.

### Como testar:
- Após o PR ser integrado, você pode testar o endpoint GET `/api/monitoramento/logs` usando o Postman ou qualquer outra ferramenta de testes de APIs.
- O retorno esperado é uma lista com todos os logs armazenados no banco de dados.

## Checklist:
- [x] O código compila corretamente
- [x] O método foi testado e funciona corretamente
