### PR TITLE
feat: exclusão de log com validação no service e controller

### DIFF
--- a/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
+++ b/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
@@ -58,4 +58,21 @@ public class MonitoramentoLogController {
         return new ResponseEntity<>(log, HttpStatus.OK);
     }
 
+
+    @Operation(summary = "Deleta um log específico")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Log deletado com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Log não encontrado")
+    })
+    @DeleteMapping("/logs/{id}")
+    public ResponseEntity<String> deletarLog(@PathVariable Long id){
+        try {
+            monitoramentoLogService.deletarPorId(id);
+            return  ResponseEntity.ok().build();
+        } catch (RecursoNaoEncontradoException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+
+
 }

--- a/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
+++ b/api/src/main/java/com/monitoramento/api/controller/MonitoramentoLogController.java
@@ -2,6 +2,7 @@ package com.monitoramento.api.controller;
 
 import com.monitoramento.api.exceptions.RecursoNaoEncontradoException;
 import com.monitoramento.api.model.MonitoramentoLog;
+import com.monitoramento.api.repository.MonitoramentoLogRepository;
 import com.monitoramento.api.service.MonitoramentoLogService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -9,6 +10,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,9 +27,12 @@ public class MonitoramentoLogController {
     @Autowired
     private MonitoramentoLogService monitoramentoLogService;
 
+    @Autowired
+    private MonitoramentoLogRepository monitoramentoLogRepository;
 
     // Configuração da documentação Swagger
-    @Operation(summary = "Criar um novo log de monitoramento")
+    @Operation(summary = "Criar um novo log de monitoramento",
+            description = "Cria um novo log de monitoramento com base nas informações fornecidas.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Log criado com sucesso"),
             @ApiResponse(responseCode = "400", description = "Dados inválidos fornecidos")
@@ -36,7 +43,8 @@ public class MonitoramentoLogController {
         return monitoramentoLogService.salvarLog(monitoramentoLog);
     }
 
-    @Operation(summary = "Lista todos os logs de monitoramento")
+    @Operation(summary = "Lista todos os logs de monitoramento",
+            description = "Recupera uma lista de todos os logs de monitoramento existentes.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Lista de logs retornada com sucesso"),
             @ApiResponse(responseCode = "404", description = "Nenhum log encontrado")
@@ -46,7 +54,8 @@ public class MonitoramentoLogController {
         return monitoramentoLogService.listarTodos();
     }
 
-    @Operation(summary = "Busca um log específico pelo ID")
+    @Operation(summary = "Busca um log específico pelo ID",
+            description = "Recupera um log de monitoramento específico com base no ID fornecido.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Retorna o log com sucesso"),
             @ApiResponse(responseCode = "404", description = "Log não encontrado")
@@ -59,7 +68,8 @@ public class MonitoramentoLogController {
     }
 
 
-    @Operation(summary = "Deleta um log específico")
+    @Operation(summary = "Deleta um log específico",
+            description = "Remove um log de monitoramento do sistema com base no ID fornecido.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Log deletado com sucesso"),
             @ApiResponse(responseCode = "404", description = "Log não encontrado")
@@ -72,6 +82,30 @@ public class MonitoramentoLogController {
         } catch (RecursoNaoEncontradoException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
+    }
+
+    @Operation(summary = "Consultar com filtros Dinamico",
+            description = "Filtra logs de monitoramento com base em parâmetros como status HTTP e nome do serviço.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Logs encontrados com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Parâmetros inválidos"),
+            @ApiResponse(responseCode = "500", description = "Erro interno do servidor")
+    })
+    @GetMapping
+    public ResponseEntity<Page<MonitoramentoLog>> getLogs(
+            @RequestParam(required = false) Integer statusHttp,
+            @RequestParam(required = false) String nomeServico,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        // Definir a paginação
+        Pageable pageable = PageRequest.of(page, size);
+
+        // Usar o metodo de filtro dinâmico no repositório
+        Page<MonitoramentoLog> logs = monitoramentoLogRepository.findAll(
+                MonitoramentoLogRepository.filtroDinamico(statusHttp, nomeServico), pageable);
+
+        return new ResponseEntity<>(logs, HttpStatus.OK);
     }
 
 

--- a/api/src/main/java/com/monitoramento/api/repository/MonitoramentoLogRepository.java
+++ b/api/src/main/java/com/monitoramento/api/repository/MonitoramentoLogRepository.java
@@ -1,9 +1,34 @@
 package com.monitoramento.api.repository;
 
 import com.monitoramento.api.model.MonitoramentoLog;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.criteria.Predicate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 @Repository
-public interface MonitoramentoLogRepository extends JpaRepository<MonitoramentoLog, Long> {
+public interface MonitoramentoLogRepository extends JpaRepository<MonitoramentoLog, Long>, JpaSpecificationExecutor<MonitoramentoLog> {
+
+    static Specification<MonitoramentoLog> filtroDinamico(Integer statusHttp, String nomeServico) {
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            // Filtro por Status HTTP
+            if (statusHttp != null) {
+                predicates.add(criteriaBuilder.equal(root.get("statusHttp"), statusHttp));
+            }
+
+            // Filtro por Nome do Serviço
+            if (nomeServico != null && !nomeServico.isEmpty()) {
+                predicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("nomeServico")), "%" + nomeServico.toLowerCase() + "%"));
+            }
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
 }

--- a/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
+++ b/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
@@ -35,4 +35,15 @@ public class MonitoramentoLogService {
         return log.get();
     }
 
+    public void deletarPorId(Long id){
+        Optional<MonitoramentoLog> log = monitoramentoLogRepository.findById(id);
+
+        if(log.isEmpty()){
+            throw new RecursoNaoEncontradoException("Log com o Id " + id + "não encontrado");
+        }
+
+        monitoramentoLogRepository.deleteById(id);
+
+    }
+
 }

--- a/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
+++ b/api/src/main/java/com/monitoramento/api/service/MonitoramentoLogService.java
@@ -46,4 +46,9 @@ public class MonitoramentoLogService {
 
     }
 
+    // Metodo para aplicar os filtros
+    public List<MonitoramentoLog> buscarDinamica(Integer statusHttp, String nomeServico) {
+        return monitoramentoLogRepository.findAll(MonitoramentoLogRepository.filtroDinamico(statusHttp, nomeServico));
+    }
+
 }


### PR DESCRIPTION
- Criado o método `deletarPorId` na classe `MonitoramentoLogService` para excluir logs pelo ID.
- Adicionada verificação para garantir que o log existe antes de realizar a exclusão.
- Tratamento de exceção `RecursoNaoEncontradoException` lançado caso o log não seja encontrado.
- Implementado o endpoint de exclusão de log no controller `MonitoramentoLogController`, com tratamento adequado para retorno de erro 404 quando o log não for encontrado.